### PR TITLE
Adds module and import support (eval)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -320,6 +320,30 @@ func (we *WhileExpression) String() string {
 	return out.String()
 }
 
+// ImportExpression represents an `import` expression and holds the name
+// of the module being imported.
+type ImportExpression struct {
+	Token token.Token // The 'import' token
+	Name  Expression
+}
+
+func (ie *ImportExpression) expressionNode() {}
+
+// TokenLiteral prints the literal value of the token associated with this node
+func (ie *ImportExpression) TokenLiteral() string { return ie.Token.Literal }
+
+// String returns a stringified version of the AST for debugging
+func (ie *ImportExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(ie.TokenLiteral())
+	out.WriteString("(")
+	out.WriteString(fmt.Sprintf("\"%s\"", ie.Name))
+	out.WriteString(")")
+
+	return out.String()
+}
+
 // FunctionLiteral represents a literal functions and holds the function's
 // formal parameters and boy of the function as a block statement
 type FunctionLiteral struct {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -6,11 +6,14 @@ package eval
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/prologic/monkey-lang/ast"
 	"github.com/prologic/monkey-lang/builtins"
+	"github.com/prologic/monkey-lang/lexer"
 	"github.com/prologic/monkey-lang/object"
+	"github.com/prologic/monkey-lang/parser"
 )
 
 var (
@@ -33,6 +36,28 @@ func fromNativeBoolean(input bool) *object.Boolean {
 
 func newError(format string, a ...interface{}) *object.Error {
 	return &object.Error{Message: fmt.Sprintf(format, a...)}
+}
+
+// EvalModule evaluates the named module and returns a *object.Module object
+func EvalModule(name string) object.Object {
+	// TODO: Add MONKEYPATH search support
+	b, err := ioutil.ReadFile(fmt.Sprintf("%s.monkey", name))
+	if err != nil {
+		return newError("IOError: error reading module '%s': %s", name, err)
+	}
+
+	l := lexer.New(string(b))
+	p := parser.New(l)
+
+	module := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		return newError("ParseError: %s", p.Errors())
+	}
+
+	env := object.NewEnvironment()
+	Eval(module, env)
+
+	return env.Hash()
 }
 
 // Eval evaluates the node and returns an object
@@ -90,6 +115,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalIfExpression(node, env)
 	case *ast.WhileExpression:
 		return evalWhileExpression(node, env)
+	case *ast.ImportExpression:
+		return evalImportExpression(node, env)
 
 	case *ast.Identifier:
 		return evalIdentifier(node, env)
@@ -496,9 +523,24 @@ func evalWhileExpression(we *ast.WhileExpression, env *object.Environment) objec
 
 	if result != nil {
 		return result
-	} else {
-		return NULL
 	}
+	return NULL
+}
+
+func evalImportExpression(ie *ast.ImportExpression, env *object.Environment) object.Object {
+	name := Eval(ie.Name, env)
+	if isError(name) {
+		return name
+	}
+
+	if s, ok := name.(*object.String); ok {
+		attrs := EvalModule(s.Value)
+		if isError(attrs) {
+			return attrs
+		}
+		return &object.Module{Name: s.Value, Attrs: attrs}
+	}
+	return newError("ImportError: invalid import path '%s'", name)
 }
 
 func isTruthy(obj object.Object) bool {
@@ -613,6 +655,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 		return evalArrayIndexExpression(left, index)
 	case left.Type() == object.HASH:
 		return evalHashIndexExpression(left, index)
+	case left.Type() == object.MODULE:
+		return evalModuleIndexExpression(left, index)
 	default:
 		return newError("index operator not supported: %s", left.Type())
 	}
@@ -632,6 +676,11 @@ func evalHashIndexExpression(hash, index object.Object) object.Object {
 	}
 
 	return pair.Value
+}
+
+func evalModuleIndexExpression(module, index object.Object) object.Object {
+	moduleObject := module.(*object.Module)
+	return evalHashIndexExpression(moduleObject.Attrs, index)
 }
 
 func evalArrayIndexExpression(array, index object.Object) object.Object {

--- a/object/environment.go
+++ b/object/environment.go
@@ -13,6 +13,18 @@ type Environment struct {
 	parent *Environment
 }
 
+// Hash returns a new Hash with the names and values of every value in the
+// environment. This is used by the module import system to wrap up the
+// evaulated module into an object.
+func (e *Environment) Hash() *Hash {
+	pairs := make(map[HashKey]HashPair)
+	for k, v := range e.store {
+		s := &String{Value: k}
+		pairs[s.HashKey()] = HashPair{Key: s, Value: v}
+	}
+	return &Hash{Pairs: pairs}
+}
+
 // Clone returns a new Environment with the parent set to the current
 // environment (enclosing environment)
 func (e *Environment) Clone() *Environment {

--- a/object/module.go
+++ b/object/module.go
@@ -1,0 +1,29 @@
+package object
+
+import (
+	"fmt"
+)
+
+// Module is the module type used to represent a collection of variabels.
+type Module struct {
+	Name  string
+	Attrs Object
+}
+
+func (m *Module) Bool() bool {
+	return true
+}
+
+func (m *Module) Compare(other Object) int {
+	return 1
+}
+
+func (m *Module) String() string {
+	return m.Inspect()
+}
+
+// Type returns the type of the object
+func (m *Module) Type() Type { return MODULE }
+
+// Inspect returns a stringified version of the object for debugging
+func (m *Module) Inspect() string { return fmt.Sprintf("<module '%s'>", m.Name) }

--- a/object/object.go
+++ b/object/object.go
@@ -44,6 +44,9 @@ const (
 
 	// HASH is the Hash object type
 	HASH = "hash"
+
+	// MODULE is the Module object type
+	MODULE = "module"
 )
 
 // Comparable is the interface for comparing two Object and their underlying

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,6 +91,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.WHILE, p.parseWhileExpression)
+	p.registerPrefix(token.IMPORT, p.parseImportExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
@@ -409,6 +410,23 @@ func (p *Parser) parseWhileExpression() ast.Expression {
 	}
 
 	expression.Consequence = p.parseBlockStatement()
+
+	return expression
+}
+
+func (p *Parser) parseImportExpression() ast.Expression {
+	expression := &ast.ImportExpression{Token: p.curToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	p.nextToken()
+	expression.Name = p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
 
 	return expression
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1302,3 +1302,23 @@ func TestParsingHashLiteralsWithExpressions(t *testing.T) {
 		testFunc(value)
 	}
 }
+
+func TestParsingImportExpressions(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`import("mod")`, `import("mod")`},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		assert.Equal(tt.expected, program.String())
+	}
+}

--- a/testdata/mod.monkey
+++ b/testdata/mod.monkey
@@ -1,0 +1,2 @@
+A := 5
+Sum := fn(a, b) { return a + b }

--- a/token/token.go
+++ b/token/token.go
@@ -136,6 +136,8 @@ const (
 	RETURN = "RETURN"
 	// WHILE the `while` keyword (while)
 	WHILE = "WHILE"
+	// IMPORT the `import` keyword (import)
+	IMPORT = "IMPORT"
 )
 
 var keywords = map[string]Type{
@@ -147,6 +149,7 @@ var keywords = map[string]Type{
 	"else":   ELSE,
 	"return": RETURN,
 	"while":  WHILE,
+	"import": IMPORT,
 }
 
 // Type represents the type of a token


### PR DESCRIPTION
Example:

With a module called `foo.monkey` in the current directory:
```#!monkey
A : = 5
Sum := fn(a, b) { return a + b }
```

The following snippet works in the evalulator:

```#!monkey
foo := import("foo")
foo.A // 5
foo.Sum(2, 3) // 5
```

TODO:

- Implement in Compiler/VM
- Only "export" capitalised bindings.
- Add support  for `MONKEYPATH` search path(s).