### PR TITLE
Added module and import support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -320,6 +320,30 @@ func (we *WhileExpression) String() string {
 	return out.String()
 }
 
+// ImportExpression represents an `import` expression and holds the name
+// of the module being imported.
+type ImportExpression struct {
+	Token token.Token // The 'import' token
+	Name  Expression
+}
+
+func (ie *ImportExpression) expressionNode() {}
+
+// TokenLiteral prints the literal value of the token associated with this node
+func (ie *ImportExpression) TokenLiteral() string { return ie.Token.Literal }
+
+// String returns a stringified version of the AST for debugging
+func (ie *ImportExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(ie.TokenLiteral())
+	out.WriteString("(")
+	out.WriteString(fmt.Sprintf("\"%s\"", ie.Name))
+	out.WriteString(")")
+
+	return out.String()
+}
+
 // FunctionLiteral represents a literal functions and holds the function's
 // formal parameters and boy of the function as a block statement
 type FunctionLiteral struct {

--- a/code/code.go
+++ b/code/code.go
@@ -79,6 +79,7 @@ const (
 	LoadLocal
 	BindLocal
 	LoadFree
+	LoadModule
 	SetSelf
 	LoadTrue
 	LoadFalse
@@ -128,6 +129,7 @@ var definitions = map[Opcode]*Definition{
 	LoadLocal:        {"LoadLocal", []int{1}},
 	BindLocal:        {"BindLocal", []int{1}},
 	LoadFree:         {"LoadFree", []int{1}},
+	LoadModule:       {"LoadModule", []int{}},
 	SetSelf:          {"SetSelf", []int{1}},
 	LoadTrue:         {"LoadTrue", []int{}},
 	LoadFalse:        {"LoadFalse", []int{}},

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -386,6 +386,16 @@ func (c *Compiler) Compile(node ast.Node) error {
 		afterConsequencePos := c.emit(code.LoadNull)
 		c.changeOperand(jumpIfFalsePos, afterConsequencePos)
 
+	case *ast.ImportExpression:
+		c.l++
+		err := c.Compile(node.Name)
+		if err != nil {
+			return err
+		}
+		c.l--
+
+		c.emit(code.LoadModule)
+
 	case *ast.PrefixExpression:
 		c.l++
 		err := c.Compile(node.Right)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1114,3 +1114,15 @@ func TestClosures(t *testing.T) {
 
 	runCompilerTests2(t, tests)
 }
+
+func TestImportExpressions(t *testing.T) {
+	tests := []compilerTestCase2{
+		{
+			input:        `import("foo")`,
+			constants:    []interface{}{"foo"},
+			instructions: "0000 LoadConstant 0\n0003 LoadModule\n0004 Pop\n",
+		},
+	}
+
+	runCompilerTests2(t, tests)
+}

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -18,7 +18,7 @@ type Symbol struct {
 type SymbolTable struct {
 	Outer *SymbolTable
 
-	store          map[string]Symbol
+	Store          map[string]Symbol
 	numDefinitions int
 
 	FreeSymbols []Symbol
@@ -27,7 +27,7 @@ type SymbolTable struct {
 func NewSymbolTable() *SymbolTable {
 	return &SymbolTable{
 		Outer:       nil,
-		store:       make(map[string]Symbol),
+		Store:       make(map[string]Symbol),
 		FreeSymbols: []Symbol{},
 	}
 }
@@ -35,7 +35,7 @@ func NewSymbolTable() *SymbolTable {
 func NewEnclosedSymbolTable(outer *SymbolTable) *SymbolTable {
 	return &SymbolTable{
 		Outer:       outer,
-		store:       make(map[string]Symbol),
+		Store:       make(map[string]Symbol),
 		FreeSymbols: []Symbol{},
 	}
 }
@@ -46,7 +46,7 @@ func (s *SymbolTable) DefineFree(original Symbol) Symbol {
 	symbol := Symbol{Name: original.Name, Index: len(s.FreeSymbols) - 1}
 	symbol.Scope = FreeScope
 
-	s.store[original.Name] = symbol
+	s.Store[original.Name] = symbol
 	return symbol
 }
 
@@ -58,19 +58,19 @@ func (s *SymbolTable) Define(name string) Symbol {
 		symbol.Scope = LocalScope
 	}
 
-	s.store[name] = symbol
+	s.Store[name] = symbol
 	s.numDefinitions++
 	return symbol
 }
 
 func (s *SymbolTable) DefineBuiltin(index int, name string) Symbol {
 	symbol := Symbol{Name: name, Index: index, Scope: BuiltinScope}
-	s.store[name] = symbol
+	s.Store[name] = symbol
 	return symbol
 }
 
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
-	obj, ok := s.store[name]
+	obj, ok := s.Store[name]
 	if !ok && s.Outer != nil {
 		obj, ok = s.Outer.Resolve(name)
 		if !ok {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prologic/monkey-lang/lexer"
 	"github.com/prologic/monkey-lang/object"
 	"github.com/prologic/monkey-lang/parser"
+	"github.com/prologic/monkey-lang/utils"
 )
 
 var (
@@ -40,8 +41,12 @@ func newError(format string, a ...interface{}) *object.Error {
 
 // EvalModule evaluates the named module and returns a *object.Module object
 func EvalModule(name string) object.Object {
-	// TODO: Add MONKEYPATH search support
-	b, err := ioutil.ReadFile(fmt.Sprintf("%s.monkey", name))
+	filename := utils.FindModule(name)
+	if filename == "" {
+		return newError("ImportError: no module named '%s'", name)
+	}
+
+	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return newError("IOError: error reading module '%s': %s", name, err)
 	}
@@ -57,7 +62,7 @@ func EvalModule(name string) object.Object {
 	env := object.NewEnvironment()
 	Eval(module, env)
 
-	return env.Hash()
+	return env.ExportedHash()
 }
 
 // Eval evaluates the node and returns an object

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -6,11 +6,14 @@ package eval
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/prologic/monkey-lang/ast"
 	"github.com/prologic/monkey-lang/builtins"
+	"github.com/prologic/monkey-lang/lexer"
 	"github.com/prologic/monkey-lang/object"
+	"github.com/prologic/monkey-lang/parser"
 )
 
 var (
@@ -33,6 +36,28 @@ func fromNativeBoolean(input bool) *object.Boolean {
 
 func newError(format string, a ...interface{}) *object.Error {
 	return &object.Error{Message: fmt.Sprintf(format, a...)}
+}
+
+// EvalModule evaluates the named module and returns a *object.Module object
+func EvalModule(name string) object.Object {
+	// TODO: Add MONKEYPATH search support
+	b, err := ioutil.ReadFile(fmt.Sprintf("%s.monkey", name))
+	if err != nil {
+		return newError("IOError: error reading module '%s': %s", name, err)
+	}
+
+	l := lexer.New(string(b))
+	p := parser.New(l)
+
+	module := p.ParseProgram()
+	if len(p.Errors()) != 0 {
+		return newError("ParseError: %s", p.Errors())
+	}
+
+	env := object.NewEnvironment()
+	Eval(module, env)
+
+	return env.Hash()
 }
 
 // Eval evaluates the node and returns an object
@@ -90,6 +115,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalIfExpression(node, env)
 	case *ast.WhileExpression:
 		return evalWhileExpression(node, env)
+	case *ast.ImportExpression:
+		return evalImportExpression(node, env)
 
 	case *ast.Identifier:
 		return evalIdentifier(node, env)
@@ -496,9 +523,24 @@ func evalWhileExpression(we *ast.WhileExpression, env *object.Environment) objec
 
 	if result != nil {
 		return result
-	} else {
-		return NULL
 	}
+	return NULL
+}
+
+func evalImportExpression(ie *ast.ImportExpression, env *object.Environment) object.Object {
+	name := Eval(ie.Name, env)
+	if isError(name) {
+		return name
+	}
+
+	if s, ok := name.(*object.String); ok {
+		attrs := EvalModule(s.Value)
+		if isError(attrs) {
+			return attrs
+		}
+		return &object.Module{Name: s.Value, Attrs: attrs}
+	}
+	return newError("ImportError: invalid import path '%s'", name)
 }
 
 func isTruthy(obj object.Object) bool {
@@ -613,6 +655,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 		return evalArrayIndexExpression(left, index)
 	case left.Type() == object.HASH:
 		return evalHashIndexExpression(left, index)
+	case left.Type() == object.MODULE:
+		return evalModuleIndexExpression(left, index)
 	default:
 		return newError("index operator not supported: %s", left.Type())
 	}
@@ -632,6 +676,11 @@ func evalHashIndexExpression(hash, index object.Object) object.Object {
 	}
 
 	return pair.Value
+}
+
+func evalModuleIndexExpression(module, index object.Object) object.Object {
+	moduleObject := module.(*object.Module)
+	return evalHashIndexExpression(moduleObject.Attrs, index)
 }
 
 func evalArrayIndexExpression(array, index object.Object) object.Object {

--- a/object/environment.go
+++ b/object/environment.go
@@ -1,5 +1,9 @@
 package object
 
+import (
+	"unicode"
+)
+
 // NewEnvironment constructs a new Environment object to hold bindings
 // of identifiers to their names
 func NewEnvironment() *Environment {
@@ -13,14 +17,17 @@ type Environment struct {
 	parent *Environment
 }
 
-// Hash returns a new Hash with the names and values of every value in the
-// environment. This is used by the module import system to wrap up the
+// ExportedHash returns a new Hash with the names and values of every publically
+// exported binding in the environment. That is every binding that starts with a
+// capital letter. This is used by the module import system to wrap up the
 // evaulated module into an object.
-func (e *Environment) Hash() *Hash {
+func (e *Environment) ExportedHash() *Hash {
 	pairs := make(map[HashKey]HashPair)
 	for k, v := range e.store {
-		s := &String{Value: k}
-		pairs[s.HashKey()] = HashPair{Key: s, Value: v}
+		if unicode.IsUpper(rune(k[0])) {
+			s := &String{Value: k}
+			pairs[s.HashKey()] = HashPair{Key: s, Value: v}
+		}
 	}
 	return &Hash{Pairs: pairs}
 }

--- a/object/environment.go
+++ b/object/environment.go
@@ -13,6 +13,18 @@ type Environment struct {
 	parent *Environment
 }
 
+// Hash returns a new Hash with the names and values of every value in the
+// environment. This is used by the module import system to wrap up the
+// evaulated module into an object.
+func (e *Environment) Hash() *Hash {
+	pairs := make(map[HashKey]HashPair)
+	for k, v := range e.store {
+		s := &String{Value: k}
+		pairs[s.HashKey()] = HashPair{Key: s, Value: v}
+	}
+	return &Hash{Pairs: pairs}
+}
+
 // Clone returns a new Environment with the parent set to the current
 // environment (enclosing environment)
 func (e *Environment) Clone() *Environment {

--- a/object/module.go
+++ b/object/module.go
@@ -1,0 +1,29 @@
+package object
+
+import (
+	"fmt"
+)
+
+// Module is the module type used to represent a collection of variabels.
+type Module struct {
+	Name  string
+	Attrs Object
+}
+
+func (m *Module) Bool() bool {
+	return true
+}
+
+func (m *Module) Compare(other Object) int {
+	return 1
+}
+
+func (m *Module) String() string {
+	return m.Inspect()
+}
+
+// Type returns the type of the object
+func (m *Module) Type() Type { return MODULE }
+
+// Inspect returns a stringified version of the object for debugging
+func (m *Module) Inspect() string { return fmt.Sprintf("<module '%s'>", m.Name) }

--- a/object/object.go
+++ b/object/object.go
@@ -44,6 +44,9 @@ const (
 
 	// HASH is the Hash object type
 	HASH = "hash"
+
+	// MODULE is the Module object type
+	MODULE = "module"
 )
 
 // Comparable is the interface for comparing two Object and their underlying

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,6 +91,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.WHILE, p.parseWhileExpression)
+	p.registerPrefix(token.IMPORT, p.parseImportExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
@@ -409,6 +410,23 @@ func (p *Parser) parseWhileExpression() ast.Expression {
 	}
 
 	expression.Consequence = p.parseBlockStatement()
+
+	return expression
+}
+
+func (p *Parser) parseImportExpression() ast.Expression {
+	expression := &ast.ImportExpression{Token: p.curToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	p.nextToken()
+	expression.Name = p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
 
 	return expression
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1302,3 +1302,23 @@ func TestParsingHashLiteralsWithExpressions(t *testing.T) {
 		testFunc(value)
 	}
 }
+
+func TestParsingImportExpressions(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`import("mod")`, `import("mod")`},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		assert.Equal(tt.expected, program.String())
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -112,7 +112,7 @@ func (r *REPL) Exec(f io.Reader) (state *vm.VMState) {
 	code := c.Bytecode()
 	state.Constants = code.Constants
 
-	machine := vm.NewWithGlobalsStore(code, state.Globals)
+	machine := vm.NewWithState(code, state)
 	machine.Debug = r.opts.Debug
 	err = machine.Run()
 	if err != nil {
@@ -196,7 +196,7 @@ func (r *REPL) StartExecLoop(in io.Reader, out io.Writer, state *vm.VMState) {
 		code := c.Bytecode()
 		state.Constants = code.Constants
 
-		machine := vm.NewWithGlobalsStore(code, state.Globals)
+		machine := vm.NewWithState(code, state)
 		machine.Debug = r.opts.Debug
 		err = machine.Run()
 		if err != nil {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/prologic/monkey-lang/builtins"
 	"github.com/prologic/monkey-lang/compiler"
 	"github.com/prologic/monkey-lang/eval"
 	"github.com/prologic/monkey-lang/lexer"
@@ -42,25 +41,6 @@ type Options struct {
 	Debug       bool
 	Engine      string
 	Interactive bool
-}
-
-type VMState struct {
-	constants []object.Object
-	globals   []object.Object
-	symbols   *compiler.SymbolTable
-}
-
-func NewVMState() *VMState {
-	symbolTable := compiler.NewSymbolTable()
-	for i, builtin := range builtins.BuiltinsIndex {
-		symbolTable.DefineBuiltin(i, builtin.Name)
-	}
-
-	return &VMState{
-		constants: []object.Object{},
-		globals:   make([]object.Object, vm.MaxGlobals),
-		symbols:   symbolTable,
-	}
 }
 
 type REPL struct {
@@ -103,14 +83,14 @@ func (r *REPL) Eval(f io.Reader) (env *object.Environment) {
 
 // Exec parses, compiles and executes the program given by f and returns
 // the resulting virtual machine, any errors are printed to stderr
-func (r *REPL) Exec(f io.Reader) (state *VMState) {
+func (r *REPL) Exec(f io.Reader) (state *vm.VMState) {
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error reading source file: %s", err)
 		return
 	}
 
-	state = NewVMState()
+	state = vm.NewVMState()
 
 	l := lexer.New(string(b))
 	p := parser.New(l)
@@ -121,7 +101,7 @@ func (r *REPL) Exec(f io.Reader) (state *VMState) {
 		return
 	}
 
-	c := compiler.NewWithState(state.symbols, state.constants)
+	c := compiler.NewWithState(state.Symbols, state.Constants)
 	c.Debug = r.opts.Debug
 	err = c.Compile(program)
 	if err != nil {
@@ -130,9 +110,9 @@ func (r *REPL) Exec(f io.Reader) (state *VMState) {
 	}
 
 	code := c.Bytecode()
-	state.constants = code.Constants
+	state.Constants = code.Constants
 
-	machine := vm.NewWithGlobalsStore(code, state.globals)
+	machine := vm.NewWithGlobalsStore(code, state.Globals)
 	machine.Debug = r.opts.Debug
 	err = machine.Run()
 	if err != nil {
@@ -180,11 +160,11 @@ func (r *REPL) StartEvalLoop(in io.Reader, out io.Writer, env *object.Environmen
 }
 
 // StartExecLoop starts the REPL in a continious exec loop
-func (r *REPL) StartExecLoop(in io.Reader, out io.Writer, state *VMState) {
+func (r *REPL) StartExecLoop(in io.Reader, out io.Writer, state *vm.VMState) {
 	scanner := bufio.NewScanner(in)
 
 	if state == nil {
-		state = NewVMState()
+		state = vm.NewVMState()
 	}
 
 	for {
@@ -205,7 +185,7 @@ func (r *REPL) StartExecLoop(in io.Reader, out io.Writer, state *VMState) {
 			continue
 		}
 
-		c := compiler.NewWithState(state.symbols, state.constants)
+		c := compiler.NewWithState(state.Symbols, state.Constants)
 		c.Debug = r.opts.Debug
 		err := c.Compile(program)
 		if err != nil {
@@ -214,9 +194,9 @@ func (r *REPL) StartExecLoop(in io.Reader, out io.Writer, state *VMState) {
 		}
 
 		code := c.Bytecode()
-		state.constants = code.Constants
+		state.Constants = code.Constants
 
-		machine := vm.NewWithGlobalsStore(code, state.globals)
+		machine := vm.NewWithGlobalsStore(code, state.Globals)
 		machine.Debug = r.opts.Debug
 		err = machine.Run()
 		if err != nil {

--- a/testdata/mod.monkey
+++ b/testdata/mod.monkey
@@ -1,0 +1,2 @@
+A := 5
+Sum := fn(a, b) { return a + b }

--- a/testdata/mod.monkey
+++ b/testdata/mod.monkey
@@ -1,2 +1,3 @@
+a := 1
 A := 5
 Sum := fn(a, b) { return a + b }

--- a/token/token.go
+++ b/token/token.go
@@ -136,6 +136,8 @@ const (
 	RETURN = "RETURN"
 	// WHILE the `while` keyword (while)
 	WHILE = "WHILE"
+	// IMPORT the `import` keyword (import)
+	IMPORT = "IMPORT"
 )
 
 var keywords = map[string]Type{
@@ -147,6 +149,7 @@ var keywords = map[string]Type{
 	"else":   ELSE,
 	"return": RETURN,
 	"while":  WHILE,
+	"import": IMPORT,
 }
 
 // Type represents the type of a token

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var SearchPaths []string
+
+func init() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("error getting cwd: %s", err)
+	}
+
+	if e := os.Getenv("MONKEYPATH"); e != "" {
+		tokens := strings.Split(e, ":")
+		for _, token := range tokens {
+			AddPath(token) // ignore errors
+		}
+	} else {
+		SearchPaths = append(SearchPaths, cwd)
+	}
+}
+
+func AddPath(path string) error {
+	path = os.ExpandEnv(filepath.Clean(path))
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	SearchPaths = append(SearchPaths, absPath)
+	return nil
+}
+
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func FindModule(name string) string {
+	basename := fmt.Sprintf("%s.monkey", name)
+	for _, p := range SearchPaths {
+		filename := filepath.Join(p, basename)
+		if Exists(filename) {
+			return filename
+		}
+	}
+	return ""
+}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prologic/monkey-lang/lexer"
 	"github.com/prologic/monkey-lang/object"
 	"github.com/prologic/monkey-lang/parser"
+	"github.com/prologic/monkey-lang/utils"
 )
 
 func parse(input string) *ast.Program {
@@ -1032,6 +1033,38 @@ func TestCallingRecursiveFunctionsInFunctions(t *testing.T) {
 			wrapper();
 			`,
 			expected: 2,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestImportExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input:    `mod := import("../testdata/mod"); mod.A`,
+			expected: 5,
+		},
+		{
+			input:    `mod := import("../testdata/mod"); mod.Sum(2, 3)`,
+			expected: 5,
+		},
+		{
+			input:    `mod := import("../testdata/mod"); mod.a`,
+			expected: nil,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestImportSearchPaths(t *testing.T) {
+	utils.AddPath("../testdata")
+
+	tests := []vmTestCase{
+		{
+			input:    `mod := import("../testdata/mod"); mod.A`,
+			expected: 5,
 		},
 	}
 


### PR DESCRIPTION
Fixes #4

Example:

With a module called `foo.monkey` in the current directory:
```#!monkey
A : = 5
Sum := fn(a, b) { return a + b }
```

The following snippet works in the evalulator:

```#!monkey
foo := import("foo")
foo.A // 5
foo.Sum(2, 3) // 5
```

TODO:

- [x] Implement in Compiler/VM
- [x] Only "export" capitalised bindings.
- [x] Add support  for `MONKEYPATH` search path(s).